### PR TITLE
HAR-70: Minor fix to OrgPage to display image

### DIFF
--- a/harmony-frontend/src/components/OrgCard/OrgCard.tsx
+++ b/harmony-frontend/src/components/OrgCard/OrgCard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { OrgService } from "../../service/orgService";
 import "./OrgCard.css";
 import { useTranslation } from "react-i18next";
-import defaultImage from "../../assets/org-default-image.jpg";
+import { ORG_IMAGE_DEFAULT } from "../../utils";
 import { Org } from "../../types/dtos/Org";
 
 const OrgCard = (org: Org) => {
@@ -32,7 +32,7 @@ const OrgCard = (org: Org) => {
             <div className="max-h-52 flex justify-center">
                 <img
                     className="h-full object-contain rounded-t-lg justify-center"
-                    src={org.image ? org.image : defaultImage}
+                    src={org.image ? org.image : ORG_IMAGE_DEFAULT}
                     alt="org image"
                 />
             </div>

--- a/harmony-frontend/src/pages/OrgPage/OrgPage.tsx
+++ b/harmony-frontend/src/pages/OrgPage/OrgPage.tsx
@@ -11,13 +11,13 @@ import EditOrgModal from "../../components/EditOrgModal/EditOrgModal";
 import { useTranslation } from "react-i18next";
 import { Song } from "../SongsPage/SongsPage.tsx";
 import { Org } from "../../types/dtos/Org.ts";
-import defaultImage from "../../assets/org-default-image.jpg";
+import { ORG_IMAGE_DEFAULT } from "../../utils.ts";
 
 const OrgPage = () => {
     const [org, setOrg]: any = useState();
     const [members, setMembers]: any = useState();
     const [songs, setSongs] = useState<Song[]>([]);
-    const [image, setImage] = useState(defaultImage);
+    const [image, setImage] = useState(ORG_IMAGE_DEFAULT);
 
     const orgId = useParams();
 

--- a/harmony-frontend/src/utils.ts
+++ b/harmony-frontend/src/utils.ts
@@ -1,3 +1,6 @@
+export const ORG_IMAGE_DEFAULT =
+    "http://localhost:54321/storage/v1/object/public/orgs_images/org-default-image.png";
+
 export const toBase64 = (file: File) =>
     new Promise((resolve, reject) => {
         const reader = new FileReader();


### PR DESCRIPTION
Quick fix on display of organization's profile image.
The default org image was uploaded to `org_images` bucket.