### PR TITLE
HAR-104: El crear una nueva organización tira error al querer mandar el mail de invitación

### DIFF
--- a/harmony-backend/service/memberService.ts
+++ b/harmony-backend/service/memberService.ts
@@ -6,12 +6,12 @@ export class MemberService {
     public static async createMember(user: number, org: number) {
         const newMember = await MemberPersistence.createMembership(user, org);
         const orgMembers = await MemberPersistence.getMembersByOrg(org);
-        // make a new array with the mails of the members of the org except the newMember
+
         const membersMails = orgMembers
             .filter((member) => member.id !== user)
             .map((member) => member.email);
-
-        await MailService.sendNewMemberJoinedMail(membersMails, org);
+        if (membersMails.length > 0)
+            await MailService.sendNewMemberJoinedMail(membersMails, org);
 
         return newMember;
     }


### PR DESCRIPTION
Se agregó un chequeo para que no se envíe un mail cuando recién se crea la organización.
Para más información, ver los comentarios en https://harmony-itba.atlassian.net/browse/HAR-104.